### PR TITLE
Use Python 3.7 as 2.7 is deprecated.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.7-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl
 


### PR DESCRIPTION
Python 2.7 is end of life, so we can't keep using it forever. Let's try 3.7 out for mkdocs instead.